### PR TITLE
Fix the `titlebar`

### DIFF
--- a/js/titlebar.js
+++ b/js/titlebar.js
@@ -14,23 +14,16 @@
 
 "use strict";
 
-const { remote } = require('electron');
+const { ipcRenderer } = require('electron');
 
 document.getElementById("minimize").addEventListener("click", function (e) {
-    var window = remote.getCurrentWindow();
-    window.minimize(); 
+    ipcRenderer.send("titlebar", "minimize");
 });
 
 document.getElementById("screenSnap").addEventListener("click", function (e) {
-    var window = remote.getCurrentWindow();
-    if (!window.isMaximized()) {
-        window.maximize();          
-    } else {
-        window.unmaximize();
-    }
+    ipcRenderer.send("titlebar", "screenSnap");
 });
 
 document.getElementById("exit").addEventListener("click", function (e) {
-    var window = remote.getCurrentWindow();
-    window.close();
+    ipcRenderer.send("titlebar", "exit");
 });

--- a/start.js
+++ b/start.js
@@ -15,7 +15,7 @@
 "use strict";
 
 const electron = require('electron');
-const { app, BrowserWindow } = electron;
+const { app, BrowserWindow, ipcMain } = electron;
 const path = require('path');
 const url = require('url');
 const pack = require('./package.json');
@@ -31,10 +31,30 @@ function createWindow() {
         webPreferences: { 
             nodeIntegration: true, // Use node in the render js files
             contextIsolation: false, // Makes node in the render js files work in newer electron versions
-            enableRemoteModule: true // Allow the remote module to be used in the render js files
         },
         icon: __dirname + '/resources/icons/logo.png',
     });
+
+    // `remote` alternative
+    ipcMain.on('titlebar', (event, message) => {
+        switch (message) {
+            case 'minimize':
+                win.minimize();
+                break;
+            case 'screenSnap':
+                if (!win.isMaximized()) {
+                    win.maximize();
+                } else {
+                    win.unmaximize();
+                }
+                break;
+            case 'exit':
+                win.close();
+                break;
+            default:
+                break;
+        }
+    })
 
     win.loadURL(
         url.pathToFileURL(path.join(__dirname, 'dontOpenMe.html')).toString()


### PR DESCRIPTION
Fixes #203 

### [`remote` has been removed from the `electron`](https://www.electronjs.org/docs/latest/breaking-changes#removed-remote-module).
I used [`ipcRenderer`](https://www.electronjs.org/docs/latest/api/ipc-renderer)

Error
```
Uncaught TypeError: Cannot read properties of undefined (reading 'getCurrentWindow')
    at HTMLDivElement.<anonymous> (titlebar.js:20:25)
```