### PR TITLE
Change CDN URL for Twemoji

### DIFF
--- a/dontOpenMe.html
+++ b/dontOpenMe.html
@@ -45,7 +45,7 @@ limitations under the License. -->
         <script src="js/showEmbed.js" charset="utf-8"></script>
         <script src="js/addMemberList.js" charset="utf-8"></script>
         <script src="js/messageGeneration.js" charset="utf-8"></script>
-        <script src="https://cdn.honeybeeks.net/twemoji.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@twemoji/api/dist/twemoji.js"></script>
         <script src="js/converter.js" charset="utf-8"></script>
         <script src="js/typingStatus.js" charset="utf-8"></script>
         <script src="js/rcMenuFuncs.js" charset="utf-8"></script>


### PR DESCRIPTION
Since there is now working alternative URL to load Twemoji script, this pull request changes CDN URL again, which was changed once before in f56858b, to load latest version of it with [`@twemoji/api`](https://www.npmjs.com/package/@twemoji/api) npm package through jsDelivr.

Following MaxCDN shutdown, one of former Twitter employee stated in twitter/twemoji#580 that they ended up creating and maintaining new fork since there can be legal consequences probably because they are no longer employed due to their boss who [cannot even write basic HTML](https://www.reddit.com/r/ProgrammerHumor/comments/zzggg5/elon_musk_cant_even_write_basic_html/), and they will maintain said fork instead of Twitter's repository. Because of that, this pull request uses [npm package](https://www.npmjs.com/package/@twemoji/api) associated with their fork, [jdecked/twemoji](https://github.com/jdecked/twemoji), instead of Twitter's package.