### PR TITLE
A quick & dirty fix for attachments.

### DIFF
--- a/js/messageGeneration.js
+++ b/js/messageGeneration.js
@@ -141,6 +141,25 @@ function generateMsgHTML(
         darkBG.appendChild(text);
     }
 
+    // Prepend attachments
+    if(m.attachments) {
+        m.attachments.forEach((i) => {
+            let attachText;
+            if(i.contentType.includes("image")) {
+                attachText = document.createElement('p');
+                showEmbed({ type: "image", thumbnail: { proxy_url: i.url, width: i.width, height: i.height } }, attachText, m);
+            }
+            if(i.contentType.includes("video")) {
+                attachText = document.createElement('p');
+                showEmbed({ type: "video", video: { url: i.url, width: i.width, height: i.height } }, attachText, m);
+            }
+            if(attachText) {
+                attachText.classList.add('messageText');
+                darkBG.appendChild(attachText)
+            }
+        });
+    }
+
     // Append embeds
     m.embeds.forEach((embed) => {
         showEmbed(embed.data, darkBG, m);


### PR DESCRIPTION
Currently:
![electron_DZcn6atXjr](https://github.com/user-attachments/assets/45b9af95-bfa8-4474-9d56-ddb53f558621)

After:
![electron_b4lSqga2lg](https://github.com/user-attachments/assets/849ce726-6505-4e3b-8723-5418698609b2)


Also works on video files.